### PR TITLE
Timezone fix

### DIFF
--- a/src/AutoHome.Client/Pages/TriggerHistory.razor
+++ b/src/AutoHome.Client/Pages/TriggerHistory.razor
@@ -23,7 +23,7 @@
             @foreach (var row in _triggerEvents)
             {
                 <tr>
-                    <td>@row.TimeStamp.LocalDateTime.ToString("yyyy/MM/dd HH:mm")</td>
+                    <td>@row.TimeStamp.LocalDateTime.ToString("yyyy-MM-dd HH:mm:ss")</td>
                     <td>@row.Trigger.Name</td>
                     <td>@row.Event</td>
                 </tr>

--- a/src/AutoHome.Server/DateTimeJsonConverter.cs
+++ b/src/AutoHome.Server/DateTimeJsonConverter.cs
@@ -1,0 +1,21 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// This converter lets us serialize datetime the same way as Newtonsoft.Json. This lets the the rest client create DateTimeOffset
+/// objects with the correct time zone info.
+/// </summary>
+public sealed class DateTimeJsonConverter : JsonConverter<DateTime>
+{
+    public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var dt = reader.GetDateTimeOffset();
+        return new DateTime(dt.UtcTicks, DateTimeKind.Utc);
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+    {
+        var isoDate = new DateTimeOffset(value).ToString("O");
+        writer.WriteStringValue(isoDate);
+    }
+}

--- a/src/AutoHome.Server/Program.cs
+++ b/src/AutoHome.Server/Program.cs
@@ -27,7 +27,11 @@ try
 
     builder.Services.AddAutoMapper(typeof(Program));
 
-    builder.Services.AddControllersWithViews();
+    builder.Services.AddControllersWithViews()
+        .AddJsonOptions(options =>
+        {
+            options.JsonSerializerOptions.Converters.Add(new DateTimeJsonConverter());
+        });
     builder.Services.AddRazorPages();
 
     builder.Services.AddDbContext<SqliteDbContext>(options =>


### PR DESCRIPTION
Fixes timezone issues

- `DbContext` now saves `DateTime`'s to the database in ISO 8601 format.
- `DbContext` now queries `DateTime`'s and produces a `DateTime` the `Kind` set to `Utc`
- Created a custom json converter for `DateTime` objects. It will now serialize a `DateTime` into ISO 8601 format. This lets the rest client create `DateTimeOffset` objects property. So that `LocalDateTime` is the passed date time with the time zone offset. And `UtcDateTime` is actually utc time.

See https://stackoverflow.com/questions/72261151/does-nswag-convert-datetime-to-datetimeoffset-in-the-timezone-the-server-is-in#:~:text=An%20application%20passes%20in%20DateTime%20values%20to%20an,So%20we%20went%20with%20DateTimeOffset%20in%20this%20scenario.